### PR TITLE
feat : mysql 설정

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - .env
     depends_on:
       - redis
+      - mysql
 
   matching:
     image: phjppo0918/party-run-matching
@@ -75,3 +76,17 @@ services:
       - TZ=Asia/Seoul
     ports:
       - 6379:6379
+  
+  mysql:
+    image: mysql:latest
+    container_name: mysql
+    restart: always
+    ports:
+      - 3306:3306 
+    env_file:
+      - .env
+    volumes:
+      - ./data/mysql/datadir:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
auth-service 측에서 mysql이 필요하기에 추가적으로 설정했습니다.
직접 compose up 및 bash 접속하여 정상적으로 동작함을 확인했습니다.
기존 env file에 
MYSQL_ROOT_PASSWORD=
MYSQL_DATABASE=

두 설정이 추가적으로 필요합니다.