### PR TITLE
feat : /members 요청에 대한 body size 향상

### DIFF
--- a/dev/data/nginx/app.conf
+++ b/dev/data/nginx/app.conf
@@ -37,6 +37,7 @@ server {
     }
 
     location /api/members {
+        client_max_body_size 10M;
         proxy_pass http://authentication:8080;
     }
 


### PR DESCRIPTION
기존에 nignx 에서 body size를 default로 1MB로 제한했습니다.
그로 인하여 이미지파일이 1MB이 넘으면 413 에러가 발생하는 문제가 있었습니다.
따라서 해당 요청이 있는 엔드포인트만 용량을 조정했습니다.