### PR TITLE
fix : nginx timeout 설정

### DIFF
--- a/dev/data/nginx/app.conf
+++ b/dev/data/nginx/app.conf
@@ -42,11 +42,19 @@ server {
     }
 
     location /api/waiting {
+        proxy_read_timeout 30m;
         proxy_buffering off;
         proxy_pass http://matching:8080;
     }
 
     location /api/matching {
+        proxy_read_timeout 30m;
+        proxy_buffering off;
+        proxy_pass http://matching:8080;
+    }
+
+    location /api/parties {
+        proxy_read_timeout 30m;
         proxy_buffering off;
         proxy_pass http://matching:8080;
     }

--- a/prd/data/nginx/app.conf
+++ b/prd/data/nginx/app.conf
@@ -42,11 +42,19 @@ server {
     }
 
     location /api/waiting {
+        proxy_read_timeout 30m;
         proxy_buffering off;
         proxy_pass http://matching:8080;
     }
 
     location /api/matching {
+        proxy_read_timeout 30m;
+        proxy_buffering off;
+        proxy_pass http://matching:8080;
+    }
+
+    location /api/parties {
+        proxy_read_timeout 30m;
         proxy_buffering off;
         proxy_pass http://matching:8080;
     }


### PR DESCRIPTION
기존에 nginx에서 proxy_read_timeout을 1분으로  default로 설정되어 있어 app에서 적용한 timeout보다 따르게 연결이 끊기는 문제가 발생했습니다. 위 문제를 해결하기 위해 nginx에서 연결을 넉넉한 시간으로 설정하고, application 측에 설정한 timeout이 반영되도록 변경하였습니다.